### PR TITLE
Improve README and cleanup Result module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # static_error_handler
+
+A minimal Python adaptation of Rust's `Result` type. Provides `Ok` and `Err`
+classes with helper methods for error handling.

--- a/src/static_error_handler.py
+++ b/src/static_error_handler.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
-from typing import TypeVar, Callable, Generic, Protocol, NoReturn
+"""Typed implementation of a minimal Result type."""
+
+from typing import TypeVar, Callable, Generic, NoReturn, TypeAlias
 from dataclasses import dataclass
-from enum import Enum, auto
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -165,4 +166,5 @@ class Err(Generic[T, E]):
         op(self.error)
         return self
 
-Result = Ok[T, E] | Err[T, E]
+# Union style alias to mirror Rust's ``Result`` type
+Result: TypeAlias = Ok[T, E] | Err[T, E]


### PR DESCRIPTION
## Summary
- document the project in README
- remove unused imports and add module docstring
- define typed alias for `Result`

## Testing
- `python -m py_compile src/static_error_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_684112604dcc832b931bf4a211433a07