### PR TITLE
Add PyPI packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@
 
 A minimal Python adaptation of Rust's `Result` type. Provides `Ok` and `Err`
 classes with helper methods for error handling.
+
+## Installation
+
+Once published on PyPI you can install the library with:
+
+```bash
+pip install static_error_handler
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "static_error_handler"
+version = "0.1.0"
+description = "A minimal Python adaptation of Rust's Result type"
+readme = "README.md"
+authors = [{name = "J-joon"}]
+license = {file = "LICENSE"}
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+py-modules = ["static_error_handler"]

--- a/src/static_error_handler.py
+++ b/src/static_error_handler.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 """Typed implementation of a minimal Result type."""
 
+__version__ = "0.1.0"
+
 from typing import TypeVar, Callable, Generic, NoReturn, TypeAlias
 from dataclasses import dataclass
 
@@ -168,3 +170,11 @@ class Err(Generic[T, E]):
 
 # Union style alias to mirror Rust's ``Result`` type
 Result: TypeAlias = Ok[T, E] | Err[T, E]
+
+__all__ = [
+    "Ok",
+    "Err",
+    "Result",
+    "panic",
+    "__version__",
+]


### PR DESCRIPTION
## Summary
- prepare library for PyPI distribution
- expose version and exports in `static_error_handler.py`
- add installation instructions in README

## Testing
- `python -m pip install build`
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_6841138a00cc832bbd914eb1487d5ae3