### PR TITLE
Update package exports and README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ Once published on PyPI you can install the library with:
 ```bash
 pip install static_error_handler
 ```
+
+## Usage
+
+```python
+from static_error_handler import Ok, Err, Result
+
+def divide(a: int, b: int) -> Result[int, str]:
+    if b == 0:
+        return Err("division by zero")
+    return Ok(a // b)
+
+result = divide(10, 2)
+print(result.unwrap())  # 5
+```

--- a/src/static_error_handler/__init__.py
+++ b/src/static_error_handler/__init__.py
@@ -1,0 +1,3 @@
+from .static_error_handler import Ok, Err, Result, panic, __version__
+
+__all__ = ["Ok", "Err", "Result", "panic", "__version__"]


### PR DESCRIPTION
## Summary
- expose core API in `__init__.py`
- document import usage in README

## Testing
- `pip install -e .`
- `python -m compileall -q src`
- `python - <<'EOF'
from static_error_handler import Ok, Err, Result
print(Ok(1).unwrap())
print(Err("error").is_err())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684a63a3b2ac832ba428e8f903a68f3e